### PR TITLE
30 webglrs update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,49 +86,64 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "warp-engine"
 version = "0.1.0"
 dependencies = [
- "wasm-bindgen 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "webgl-rs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webgl-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.13"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen-macro 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.13"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.13"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.13"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -129,16 +152,17 @@ dependencies = [
 
 [[package]]
 name = "webgl-rs"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
+"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "61bd98ae7f7b754bc53dca7d44b604f733c6bba044ea6f41bc8d89272d8161d2"
 "checksum proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "cccdc7557a98fe98453030f077df7f3a042052fae465bb61d2c2c41435cfd9b6"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
@@ -147,8 +171,10 @@ dependencies = [
 "checksum serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c6908c7b925cd6c590358a4034de93dbddb20c45e1d021931459fd419bf0e2"
 "checksum syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2beff8ebc3658f07512a413866875adddd20f4fd47b2a4e6c9da65cd281baaea"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum wasm-bindgen 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3df31dd01855d505f6803543163d6fb91a862e6367aa131457c394df16b61b"
-"checksum wasm-bindgen-backend 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f34e8a156d16efdab59670345bcd1a8d9fbbee21287f1a8c5dc8eef803b04579"
-"checksum wasm-bindgen-macro 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "c4a727111f4f801c1b61769bfa16918e0d43bab56a5aa749c1f50bac5f09dd45"
-"checksum wasm-bindgen-shared 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "42102375e464d7e93c75e60cce561b807c3242735dd4dfe4bf460008988e63bf"
-"checksum webgl-rs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5de3e6455fd3cb3f9795499ea89b73db40802a4d79a5849f610580cbf277361"
+"checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
+"checksum wasm-bindgen 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "18435dd2cabae856f7ce0530798d1b9d0f9fe52f0948abb4b002d5d6042aa479"
+"checksum wasm-bindgen-backend 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "d86e94290104554e5e4b9030ed90623033707fb0275151325faff4e4953bcfee"
+"checksum wasm-bindgen-macro 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "e240c96a612f131b87a1925c15ba73ce9f71b7e443c42c8ec9c77cfdc06c58a1"
+"checksum wasm-bindgen-macro-support 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "40b6edde67171a5a8514243049e85593e4a776446fe952d9e1873b828e28ecc0"
+"checksum wasm-bindgen-shared 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "19647b4790a288a74d4a9911fbf6e66719a3eca36d2ea755412fe2cd615bec93"
+"checksum webgl-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9a720496b0b8d086656c55a77bfd198de08a969b58ecd335ffaa202018951a69"

--- a/warp-engine/Cargo.toml
+++ b/warp-engine/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 #wasm-bindgen = { git = "https://github.com/rustwasm/wasm-bindgen" }
-wasm-bindgen = "^0.2.13"
-webgl-rs = "^0.1.0"
+wasm-bindgen = "^0.2.17"
+webgl-rs = "^0.2.0"
 #glenum-bindgen = { path = "../glenum-bindgen" }
 #webgl2-bindgen = { path = "../webgl2-bindgen" }

--- a/warp-engine/src/graphics/webgl/binding.rs
+++ b/warp-engine/src/graphics/webgl/binding.rs
@@ -2,25 +2,25 @@ use super::{matter::Matter, program::Program};
 use log::log;
 use wasm_bindgen::prelude::*;
 use webgl_rs::{AttributeSize, AttributeType};
-use webgl_rs::{WebGL2RenderingContext, WebGLVertexArrayObject};
+use webgl_rs::{WebGL2RenderingContext, WebGLRSVertexArrayObject};
 
-#[wasm_bindgen]
-pub struct Binding {
-    context: WebGL2RenderingContext,
-    vao: WebGLVertexArrayObject,
+//#[wasm_bindgen]
+pub struct Binding<'a> {
+    context: &'a WebGL2RenderingContext,
+    vao: WebGLRSVertexArrayObject<'a>,
 }
 
-#[wasm_bindgen]
-impl Binding {
+//#[wasm_bindgen]
+impl<'a> Binding<'a> {
     pub fn new(
-        context: WebGL2RenderingContext,
+        context: &'a WebGL2RenderingContext,
         program: &Program,
         matter: &Matter,
         attribute: &str,
-    ) -> Binding {
+    ) -> Binding<'a> {
         let attrib_loc = program.get_location(attribute);
         let vao = context.create_vertex_array();
-        context.bind_vertex_array(&vao);
+        vao.bind();
         context.enable_vertex_attrib_array(attrib_loc);
         matter.bind();
         // FIXME attributesize, stride depending on matter
@@ -36,6 +36,6 @@ impl Binding {
     }
 
     pub fn enable(&self) {
-        self.context.bind_vertex_array(&self.vao);
+        self.vao.bind();
     }
 }

--- a/warp-engine/src/graphics/webgl/buffer.rs
+++ b/warp-engine/src/graphics/webgl/buffer.rs
@@ -1,16 +1,17 @@
 use log::log;
 use wasm_bindgen::prelude::*;
+use webgl_rs::data_view::Buffer as BufferView;
 use webgl_rs::{BufferKind, DataHint};
-use webgl_rs::{WebGL2RenderingContext, WebGLBuffer};
+use webgl_rs::{WebGL2RenderingContext, WebGLRSBuffer};
 
-pub struct Buffer {
-    context: WebGL2RenderingContext,
+pub struct Buffer<'a> {
+    context: &'a WebGL2RenderingContext,
     kind: BufferKind,
-    buffer: WebGLBuffer,
+    buffer: WebGLRSBuffer<'a>,
 }
 
-impl Buffer {
-    pub fn new(context: WebGL2RenderingContext, kind: BufferKind) -> Buffer {
+impl<'a> Buffer<'a> {
+    pub fn new(context: &'a WebGL2RenderingContext, kind: BufferKind) -> Buffer<'a> {
         let buffer = context.create_buffer();
 
         Buffer {
@@ -20,15 +21,15 @@ impl Buffer {
         }
     }
 
-    pub fn load_data(&self, data: Vec<u8>, draw_mode: DataHint) {
-        let length = data.len();
-        self.context.bind_buffer(self.kind, &self.buffer);
+    pub fn load_data<B: BufferView>(&self, data: &B, draw_mode: DataHint) {
+        //let length = data.len();
+        self.buffer.bind(self.kind);
         self.context.buffer_data(self.kind, data, draw_mode);
 
         //TODO maybe find a way to bind_buffer to null to unbind
     }
 
     pub fn bind(&self) {
-        self.context.bind_buffer(self.kind, &self.buffer);
+        self.buffer.bind(self.kind);
     }
 }

--- a/warp-engine/src/graphics/webgl/matter.rs
+++ b/warp-engine/src/graphics/webgl/matter.rs
@@ -5,20 +5,24 @@ use wasm_bindgen::prelude::*;
 use webgl_rs::WebGL2RenderingContext;
 use webgl_rs::{BufferKind, DataHint};
 
-#[wasm_bindgen]
-pub struct Matter {
-    context: WebGL2RenderingContext,
-    vertex_buffer: Buffer,
-    index_buffer: Buffer,
+//#[wasm_bindgen]
+pub struct Matter<'a> {
+    context: &'a WebGL2RenderingContext,
+    vertex_buffer: Buffer<'a>,
+    index_buffer: Buffer<'a>,
 }
 
-#[wasm_bindgen]
-impl Matter {
-    pub fn new(context: WebGL2RenderingContext, vertices: Vec<f32>, indices: Vec<u16>) -> Matter {
-        let vertex_buffer = Buffer::new(context.clone(), BufferKind::Array);
-        vertex_buffer.load_data(vertices.into_bytes(), DataHint::StaticDraw);
-        let index_buffer = Buffer::new(context.clone(), BufferKind::ElementArray);
-        index_buffer.load_data(indices.into_bytes(), DataHint::StaticDraw);
+//#[wasm_bindgen]
+impl<'a> Matter<'a> {
+    pub fn new(
+        context: &'a WebGL2RenderingContext,
+        vertices: &Vec<f32>,
+        indices: &Vec<u16>,
+    ) -> Matter<'a> {
+        let vertex_buffer = Buffer::new(context, BufferKind::Array);
+        vertex_buffer.load_data(vertices, DataHint::StaticDraw);
+        let index_buffer = Buffer::new(context, BufferKind::ElementArray);
+        index_buffer.load_data(indices, DataHint::StaticDraw);
         Matter {
             context,
             vertex_buffer,

--- a/warp-engine/src/graphics/webgl/program.rs
+++ b/warp-engine/src/graphics/webgl/program.rs
@@ -1,26 +1,26 @@
 use graphics::webgl::shader::Shader;
 use wasm_bindgen::prelude::*;
-use webgl_rs::{WebGL2RenderingContext, WebGLProgram};
+use webgl_rs::{WebGL2RenderingContext, WebGLRSProgram};
 
-#[wasm_bindgen]
-pub struct Program {
-    context: WebGL2RenderingContext,
-    program: WebGLProgram,
-    vertex_shader: Shader,
-    fragment_shader: Shader,
+//#[wasm_bindgen]
+pub struct Program<'a> {
+    context: &'a WebGL2RenderingContext,
+    program: WebGLRSProgram<'a>,
+    vertex_shader: Shader<'a>,
+    fragment_shader: Shader<'a>,
 }
 
-#[wasm_bindgen]
-impl Program {
+//#[wasm_bindgen]
+impl<'a> Program<'a> {
     pub fn new(
-        context: WebGL2RenderingContext,
-        vertex_shader: Shader,
-        fragment_shader: Shader,
-    ) -> Program {
+        context: &'a WebGL2RenderingContext,
+        vertex_shader: Shader<'a>,
+        fragment_shader: Shader<'a>,
+    ) -> Program<'a> {
         let program = context.create_program();
-        context.attach_shader(&program, vertex_shader.shader());
-        context.attach_shader(&program, fragment_shader.shader());
-        context.link_program(&program);
+        program.attach_shader(vertex_shader.shader());
+        program.attach_shader(fragment_shader.shader());
+        program.link();
         Program {
             context,
             program,
@@ -30,10 +30,10 @@ impl Program {
     }
 
     pub fn enable(&self) {
-        self.context.use_program(&self.program);
+        self.program.enable();
     }
 
     pub fn get_location(&self, attribute: &str) -> u32 {
-        self.context.get_attrib_location(&self.program, attribute)
+        self.program.attrib_location(attribute)
     }
 }

--- a/warp-engine/src/graphics/webgl/shader.rs
+++ b/warp-engine/src/graphics/webgl/shader.rs
@@ -1,20 +1,20 @@
 use wasm_bindgen::prelude::*;
 use webgl_rs::ShaderKind;
-use webgl_rs::{WebGL2RenderingContext, WebGLShader};
+use webgl_rs::{WebGL2RenderingContext, WebGLRSShader};
 
-#[wasm_bindgen]
-pub struct Shader {
-    context: WebGL2RenderingContext,
-    shader: WebGLShader,
+//#[wasm_bindgen]
+pub struct Shader<'a> {
+    context: &'a WebGL2RenderingContext,
+    shader: WebGLRSShader<'a>,
     kind: ShaderKind,
 }
 
-#[wasm_bindgen]
-impl Shader {
-    pub fn new(context: WebGL2RenderingContext, code: &str, kind: ShaderKind) -> Shader {
+//#[wasm_bindgen]
+impl<'a> Shader<'a> {
+    pub fn new(context: &'a WebGL2RenderingContext, code: &str, kind: ShaderKind) -> Shader<'a> {
         let shader = context.create_shader(kind);
-        context.shader_source(&shader, code);
-        context.compile_shader(&shader);
+        shader.shader_source(code);
+        shader.compile();
         //TODO log result of compilation
         Shader {
             context,
@@ -22,10 +22,7 @@ impl Shader {
             kind,
         }
     }
-}
-
-impl Shader {
-    pub fn shader(&self) -> &WebGLShader {
+    pub fn shader(&self) -> &WebGLRSShader {
         &self.shader
     }
 }

--- a/warp-engine/src/graphics/webgl/shader.rs
+++ b/warp-engine/src/graphics/webgl/shader.rs
@@ -13,7 +13,7 @@ pub struct Shader<'a> {
 impl<'a> Shader<'a> {
     pub fn new(context: &'a WebGL2RenderingContext, code: &str, kind: ShaderKind) -> Shader<'a> {
         let shader = context.create_shader(kind);
-        shader.shader_source(code);
+        shader.set_shader_source(code);
         shader.compile();
         //TODO log result of compilation
         Shader {

--- a/warp-engine/src/lib.rs
+++ b/warp-engine/src/lib.rs
@@ -1,10 +1,6 @@
-#![feature(use_extern_macros, wasm_import_module)]
-#![recursion_limit = "500"]
+#![feature(use_extern_macros)]
 
-//extern crate glenum_bindgen;
 extern crate wasm_bindgen;
-// FIXME: wasm_bindgen currently errors when trying to load exported bindings from other crates
-//extern crate webgl2_bindgen;
 extern crate webgl_rs;
 
 pub mod graphics;


### PR DESCRIPTION
remove wasm_bindgen bindings for now as they don't support enough as of yet for our usecases and as their is no way to call js from wasm anyways.
closes #30 